### PR TITLE
guarantee that $group maintains sort order

### DIFF
--- a/index.js
+++ b/index.js
@@ -274,9 +274,10 @@ Repository.prototype._getAllSnapshots = function _getAllSnapshots (ids, cb) {
   var self = this;
 
   var match = { $match: { id: { $in: ids } } };
+  var sort = { $sort: { snapshotVersion: 1 } };
   var group = { $group: { _id: '$id', snapshotVersion: { $last: '$snapshotVersion' } } };
 
-  self.snapshots.aggregate([match, group], function (err, idVersionPairs) {
+  self.snapshots.aggregate([match, sort, group], function (err, idVersionPairs) {
     if (err) return cb(err);
     var criteria = {};
     if (idVersionPairs.length === 0) {


### PR DESCRIPTION
When using $last in a $group stage, the $group stage should follow a $sort stage to have the input documents in a defined order.

Although the $sort stage passes ordered documents as input to the $group stage, $group is not guaranteed to maintain this sort order in its own output.