### PR TITLE
fix: update vulnerable dependencies

### DIFF
--- a/index.js
+++ b/index.js
@@ -74,7 +74,7 @@ Repository.prototype.commitAll = function commit (entities, options, cb) {
 
   var self = this;
 
-  log('committing %s for id %j', this.entityType.name, _.pluck(entities, 'id'));
+  log('committing %s for id %j', this.entityType.name, _.map(entities, 'id'));
 
   this._commitAllEvents(entities, function _afterCommitEvents (err) {
     if (err) return cb(err);
@@ -198,7 +198,7 @@ Repository.prototype._commitAllEvents = function _commitEvents (entities, cb) {
 
   self.events.insert(events, function (err) {
     if (err) return cb(err);
-    log('committed %s.events for ids %j', self.entityType.name, _.pluck(entities, 'id'));
+    log('committed %s.events for ids %j', self.entityType.name, _.map(entities, 'id'));
     entities.forEach(function (entity) {
       entity.newEvents = [];
     });
@@ -242,7 +242,7 @@ Repository.prototype._commitAllSnapshots = function _commitAllSnapshots (entitie
 
   self.snapshots.insert(snapshots, function (err) {
     if (err) return cb(err);
-    log('committed %s.snapshot for ids %s %j', self.entityType.name, _.pluck(entities, 'id'), snapshots);
+    log('committed %s.snapshot for ids %s %j', self.entityType.name, _.map(entities, 'id'), snapshots);
     return cb(null, entities);
   });
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sourced-repo-mongo",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -27,9 +27,9 @@
       "dev": true
     },
     "bson": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/bson/-/bson-1.0.6.tgz",
-      "integrity": "sha512-D8zmlb46xfuK2gGvKmUjIklQEouN2nQ0LEHHeZ/NoHM2LDiMk2EYzZ5Ntw/Urk+bgMDosOZxaRzXxvhI5TcAVQ=="
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/bson/-/bson-1.0.9.tgz",
+      "integrity": "sha512-IQX9/h7WdMBIW/q/++tGd+emQr0XMdeZ6icnT/74Xk9fnabWn+gZgpE+9V+gujL3hhJOoNrnDVY7tWdzc7NUTg=="
     },
     "commander": {
       "version": "2.15.1",
@@ -49,13 +49,6 @@
       "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
       "requires": {
         "ms": "2.0.0"
-      },
-      "dependencies": {
-        "ms": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
-        }
       }
     },
     "diff": {
@@ -71,9 +64,9 @@
       "dev": true
     },
     "extend": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/extend/-/extend-1.3.0.tgz",
-      "integrity": "sha1-0VFvsP9WJNLr+RI+odrFoZlABPg="
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
+      "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ="
     },
     "fs.realpath": {
       "version": "1.0.0",
@@ -130,9 +123,9 @@
       "dev": true
     },
     "lodash": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
-      "integrity": "sha1-+t2DS5aDBz2hebPq5tnA0VBT9z4="
+      "version": "4.17.10",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
+      "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg=="
     },
     "minimatch": {
       "version": "3.0.4",
@@ -178,21 +171,26 @@
       }
     },
     "mongodb": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-3.0.5.tgz",
-      "integrity": "sha512-8ioTyyc8tkNwZCTDa1FPWvmpJFfvE484DnugC8KpVrw4AKAE03OOAlORl2yYTNtz3TX4Ab7FRo00vzgexB/67A==",
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-3.0.10.tgz",
+      "integrity": "sha512-jy9s4FgcM4rl8sHNETYHGeWcuRh9AlwQCUuMiTj041t/HD02HwyFgmm2VZdd9/mA9YNHaUJLqj0tzBx2QFivtg==",
       "requires": {
-        "mongodb-core": "3.0.5"
+        "mongodb-core": "3.0.9"
       }
     },
     "mongodb-core": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/mongodb-core/-/mongodb-core-3.0.5.tgz",
-      "integrity": "sha512-4A1nx/xAU5d/NPICjiyzVxzNrIdJQQsYRe3xQkV1O638t+fHHfAOLK+SQagqGnu1m0aeSxb1ixp/P0FGSQWIGA==",
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/mongodb-core/-/mongodb-core-3.0.9.tgz",
+      "integrity": "sha512-buOWjdLLBlEqjHDeHYSXqXx173wHMVp7bafhdHxSjxWdB9V6Ri4myTqxjYZwL/eGFZxvd8oRQSuhwuIDbaaB+g==",
       "requires": {
         "bson": "~1.0.4",
         "require_optional": "^1.0.1"
       }
+    },
+    "ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
     },
     "once": {
       "version": "1.4.0",
@@ -229,38 +227,57 @@
       "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA=="
     },
     "should": {
-      "version": "4.6.5",
-      "resolved": "https://registry.npmjs.org/should/-/should-4.6.5.tgz",
-      "integrity": "sha1-DRI0bbvRsCj59Lt6nVRzZPw2qH8=",
+      "version": "13.2.1",
+      "resolved": "https://registry.npmjs.org/should/-/should-13.2.1.tgz",
+      "integrity": "sha512-l+/NwEMO+DcstsHEwPHRHzC9j4UOE3VQwJGcMWSsD/vqpqHbnQ+1iSHy64Ihmmjx1uiRPD9pFadTSc3MJtXAgw==",
       "dev": true,
       "requires": {
-        "should-equal": "0.3.1",
-        "should-format": "0.0.7",
-        "should-type": "0.0.4"
+        "should-equal": "^2.0.0",
+        "should-format": "^3.0.3",
+        "should-type": "^1.4.0",
+        "should-type-adaptors": "^1.0.1",
+        "should-util": "^1.0.0"
       }
     },
     "should-equal": {
-      "version": "0.3.1",
-      "resolved": "http://registry.npmjs.org/should-equal/-/should-equal-0.3.1.tgz",
-      "integrity": "sha1-vY6pemdI45+tR2o75v1y68LnK/A=",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/should-equal/-/should-equal-2.0.0.tgz",
+      "integrity": "sha512-ZP36TMrK9euEuWQYBig9W55WPC7uo37qzAEmbjHz4gfyuXrEUgF8cUvQVO+w+d3OMfPvSRQJ22lSm8MQJ43LTA==",
       "dev": true,
       "requires": {
-        "should-type": "0.0.4"
+        "should-type": "^1.4.0"
       }
     },
     "should-format": {
-      "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/should-format/-/should-format-0.0.7.tgz",
-      "integrity": "sha1-Hi74a9kdqcLgQSM1tWq6vZov3hI=",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/should-format/-/should-format-3.0.3.tgz",
+      "integrity": "sha1-m/yPdPo5IFxT04w01xcwPidxJPE=",
       "dev": true,
       "requires": {
-        "should-type": "0.0.4"
+        "should-type": "^1.3.0",
+        "should-type-adaptors": "^1.0.1"
       }
     },
     "should-type": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/should-type/-/should-type-0.0.4.tgz",
-      "integrity": "sha1-ATKgVBemEmhmQmrPEW8e1WI6XNA=",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/should-type/-/should-type-1.4.0.tgz",
+      "integrity": "sha1-B1bYzoRt/QmEOmlHcZ36DUz/XPM=",
+      "dev": true
+    },
+    "should-type-adaptors": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/should-type-adaptors/-/should-type-adaptors-1.1.0.tgz",
+      "integrity": "sha512-JA4hdoLnN+kebEp2Vs8eBe9g7uy0zbRo+RMcU0EsNy+R+k049Ki+N5tT5Jagst2g7EAja+euFuoXFCa8vIklfA==",
+      "dev": true,
+      "requires": {
+        "should-type": "^1.3.0",
+        "should-util": "^1.0.0"
+      }
+    },
+    "should-util": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/should-util/-/should-util-1.0.0.tgz",
+      "integrity": "sha1-yYzaN0qmsZDfi6h8mInCtNtiAGM=",
       "dev": true
     },
     "sourced": {
@@ -276,6 +293,11 @@
           "version": "0.7.4",
           "resolved": "https://registry.npmjs.org/debug/-/debug-0.7.4.tgz",
           "integrity": "sha1-BuHqgILCyxTjmAbiLi9vdX+Srzk="
+        },
+        "lodash": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
+          "integrity": "sha1-+t2DS5aDBz2hebPq5tnA0VBT9z4="
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -8,14 +8,14 @@
   },
   "dependencies": {
     "debug": "^3.1.0",
-    "extend": "^1.2.1",
-    "lodash": "^2.4.1",
-    "mongodb": "^3.0.5",
+    "extend": "^3.0.1",
+    "lodash": "^4.17.10",
+    "mongodb": "^3.0.10",
     "sourced": "0.1.4"
   },
   "devDependencies": {
     "mocha": "^5.2.0",
-    "should": "^4.0.0"
+    "should": "^13.2.1"
   },
   "scripts": {
     "test": "mocha test -R spec --exit"


### PR DESCRIPTION
https://stackoverflow.com/questions/35136306/what-happened-to-lodash-pluck

```
var objects = [{ 'a': 1 }, { 'a': 2 }];

// in 3.10.1
_.pluck(objects, 'a'); // → [1, 2]
_.map(objects, 'a'); // → [1, 2]

// in 4.0.0
_.map(objects, 'a'); // → [1, 2]
```

A few tests failed, when I changed to map they passed again.