### PR TITLE
rid of deprecated mongodb methods

### DIFF
--- a/mongo.js
+++ b/mongo.js
@@ -13,7 +13,7 @@ function Mongo () {
 
 util.inherits(Mongo, EventEmitter);
 
-Mongo.prototype.connect = function connect (mongoUrl) {
+Mongo.prototype.connect = function connect (mongoUrl, connectOptions = { useNewUrlParser: true }) {
   var self = this;
   return new Promise((resolve, reject) => {
     self.on('connected', (db) => {
@@ -22,7 +22,8 @@ Mongo.prototype.connect = function connect (mongoUrl) {
     self.on('error', (err) => {
       reject(err)
     })
-    MongoClient.connect(mongoUrl, function (err, client) {
+
+    MongoClient.connect(mongoUrl, connectOptions, function (err, client) {
       if (err) {
         log('✗ MongoDB Connection Error. Please make sure MongoDB is running: ', err);
         self.emit('error', err);


### PR DESCRIPTION
New mongodb client (3.1.10) which is in `package-lock.json` is throwing warnings like: 

* `DeprecationWarning: collection.ensureIndex is deprecated. Use createIndexes instead`
* `DeprecationWarning: collection.ensureIndex is deprecated. Use createIndexes instead.`
* `DeprecationWarning: collection.insert is deprecated. Use insertOne, insertMany or bulkWrite instead`

This PR will fix those by using the new methods.